### PR TITLE
Handle permission errors when storing uploads locally

### DIFF
--- a/src/app/api/uploads/[...path]/route.ts
+++ b/src/app/api/uploads/[...path]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { readFile, stat } from "fs/promises";
 import path from "path";
+import { getLocalUploadRoot } from "@/lib/storage/local-paths";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -39,7 +40,7 @@ function buildHeaders(stats: { size: number; mtime: Date }) {
 
 async function resolveFile(request: NextRequest, params: string[]) {
   void request;
-  const uploadsRoot = path.resolve(process.cwd(), "public", "uploads") + path.sep;
+  const uploadsRoot = path.resolve(getLocalUploadRoot()) + path.sep;
   const filePath = path.resolve(uploadsRoot, ...params);
 
   if (!filePath.startsWith(uploadsRoot)) {

--- a/src/lib/storage/local-paths.ts
+++ b/src/lib/storage/local-paths.ts
@@ -1,0 +1,50 @@
+import os from "os";
+import path from "path";
+
+const CONFIGURED_ROOT = (() => {
+  const explicit = process.env.LOCAL_UPLOAD_DIR || process.env.LOCAL_UPLOAD_ROOT || null;
+  return explicit ? path.resolve(explicit) : path.join(process.cwd(), "public", "uploads");
+})();
+
+let currentRoot = CONFIGURED_ROOT;
+
+export function getLocalUploadRoot(): string {
+  return currentRoot;
+}
+
+export function setLocalUploadRoot(nextRoot: string) {
+  currentRoot = path.resolve(nextRoot);
+}
+
+export function getFallbackUploadRoot(): string {
+  return path.join(os.tmpdir(), "tdp-uploads");
+}
+
+export function resolveLocalUploadPath(...segments: string[]): string {
+  return path.join(getLocalUploadRoot(), ...segments);
+}
+
+export function resolveLocalPathFromPublicUrl(relativePath: string): string {
+  const sanitized = relativePath.startsWith("/") ? relativePath.slice(1) : relativePath;
+
+  if (sanitized.startsWith("http://") || sanitized.startsWith("https://")) {
+    return sanitized;
+  }
+
+  const parts = sanitized.split("/").filter(Boolean);
+
+  if (parts[0] === "api" && parts[1] === "uploads") {
+    return path.join(getLocalUploadRoot(), ...parts.slice(2));
+  }
+
+  return path.join(getLocalUploadRoot(), sanitized);
+}
+
+export function isPermissionError(error: unknown): error is NodeJS.ErrnoException {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === "EACCES" || code === "EPERM";
+}

--- a/src/lib/storage/local-storage.ts
+++ b/src/lib/storage/local-storage.ts
@@ -1,46 +1,76 @@
 import { mkdir, writeFile, unlink, stat } from "fs/promises";
 import path from "path";
+import {
+  getFallbackUploadRoot,
+  getLocalUploadRoot,
+  isPermissionError,
+  resolveLocalPathFromPublicUrl,
+  resolveLocalUploadPath,
+  setLocalUploadRoot,
+} from "./local-paths";
 import type { StorageProvider } from "./types";
 
 export class LocalStorage implements StorageProvider {
   private uploadRoot: string;
 
   constructor() {
-    this.uploadRoot = path.join(process.cwd(), "public", "uploads");
+    this.uploadRoot = getLocalUploadRoot();
   }
 
   async upload(buffer: Buffer, filename: string, _mimeType: string): Promise<string> {
-    const dir = path.join(this.uploadRoot, "gallery");
-    await mkdir(dir, { recursive: true });
-    const filePath = path.join(dir, filename);
-    await writeFile(filePath, buffer);
+    let dir = await this.ensureGalleryDir();
+    let filePath = path.join(dir, filename);
+
+    try {
+      await writeFile(filePath, buffer);
+    } catch (error) {
+      if (!isPermissionError(error)) {
+        throw error;
+      }
+
+      dir = await this.switchToFallback();
+      filePath = path.join(dir, filename);
+      await writeFile(filePath, buffer);
+    }
+
     return `/api/uploads/gallery/${filename}`;
   }
 
   async uploadBatch(
     files: { buffer: Buffer; filename: string; mimeType: string }[]
   ): Promise<string[]> {
-    const dir = path.join(this.uploadRoot, "gallery");
-    await mkdir(dir, { recursive: true });
+    let dir = await this.ensureGalleryDir();
 
-    const results = await Promise.all(
-      files.map(async (file) => {
-        const filePath = path.join(dir, file.filename);
-        await writeFile(filePath, file.buffer);
-        return `/api/uploads/gallery/${file.filename}`;
-      })
-    );
+    try {
+      await Promise.all(
+        files.map(async (file) => {
+          const filePath = path.join(dir, file.filename);
+          await writeFile(filePath, file.buffer);
+        })
+      );
+    } catch (error) {
+      if (!isPermissionError(error)) {
+        throw error;
+      }
 
-    return results;
+      dir = await this.switchToFallback();
+      await Promise.all(
+        files.map(async (file) => {
+          const filePath = path.join(dir, file.filename);
+          await writeFile(filePath, file.buffer);
+        })
+      );
+    }
+
+    return files.map((file) => `/api/uploads/gallery/${file.filename}`);
   }
 
   async delete(relativePath: string): Promise<void> {
-    const sanitized = relativePath.startsWith("/") ? relativePath.slice(1) : relativePath;
-    const fullPath = path.join(process.cwd(), "public", sanitized);
+    const localPath = resolveLocalPathFromPublicUrl(relativePath);
 
     try {
-      await stat(fullPath);
-      await unlink(fullPath);
+      await stat(localPath);
+      await unlink(localPath);
     } catch {
       // File doesn't exist, ignore
     }
@@ -48,5 +78,29 @@ export class LocalStorage implements StorageProvider {
 
   getPublicUrl(path: string): string {
     return path;
+  }
+
+  private async ensureGalleryDir(): Promise<string> {
+    const dir = resolveLocalUploadPath("gallery");
+
+    try {
+      await mkdir(dir, { recursive: true });
+      this.uploadRoot = getLocalUploadRoot();
+      return dir;
+    } catch (error) {
+      if (!isPermissionError(error)) {
+        throw error;
+      }
+      return this.switchToFallback();
+    }
+  }
+
+  private async switchToFallback(): Promise<string> {
+    const fallbackRoot = getFallbackUploadRoot();
+    const fallbackDir = path.join(fallbackRoot, "gallery");
+    await mkdir(fallbackDir, { recursive: true });
+    setLocalUploadRoot(fallbackRoot);
+    this.uploadRoot = fallbackRoot;
+    return fallbackDir;
   }
 }


### PR DESCRIPTION
## Summary
- add helpers to centralize the writable upload root and provide a tmp-based fallback when the default path is read-only
- update local storage write/delete logic and the generic upload utility to retry in the fallback location
- use the resolved upload root when serving files so live photo assets remain accessible after fallback

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e9218b38e08328a0e18ec542a2f08b