### PR TITLE
chore(test): optimize Vitest worker pool to prevent orphan processes

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "db:migrate": "prisma migrate deploy",
     "db:generate": "prisma generate",
     "db:studio": "prisma studio",
+    "test:cleanup": "pkill -9 -f 'node.*vitest' || true",
+    "pretest": "npm run test:cleanup",
     "test": "vitest",
     "test:run": "vitest run",
     "test:watch": "vitest --watch",

--- a/scripts/check-orphans.sh
+++ b/scripts/check-orphans.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# 检查并清理孤儿 Vitest 进程
+# 用法: ./scripts/check-orphans.sh [--auto]
+
+set -e
+
+echo "🔍 检查孤儿 Vitest 进程..."
+
+# 查找所有 vitest 进程
+orphan_count=$(pgrep -fl vitest 2>/dev/null | wc -l | tr -d ' ')
+
+if [ "$orphan_count" -eq 0 ]; then
+  echo "✅ 未发现孤儿进程"
+  exit 0
+fi
+
+echo "⚠️  发现 $orphan_count 个 Vitest 进程:"
+echo ""
+pgrep -fl vitest
+
+# 显示内存占用
+echo ""
+echo "📊 内存占用情况:"
+ps -o pid,ppid,rss,comm -p $(pgrep vitest | tr '\n' ',' | sed 's/,$//') 2>/dev/null | awk '
+  NR==1 {print $0; next}
+  {total+=$3; print $0}
+  END {printf "\n总内存: %.2f GB\n", total/1024/1024}
+'
+
+# 自动模式或询问用户
+if [ "$1" = "--auto" ]; then
+  echo ""
+  echo "🧹 自动清理模式，正在清理..."
+  pkill -9 -f 'node.*vitest'
+  echo "✅ 清理完成"
+else
+  echo ""
+  read -p "是否清理这些进程？(y/n) " -n 1 -r
+  echo ""
+  if [[ $REPLY =~ ^[Yy]$ ]]; then
+    pkill -9 -f 'node.*vitest'
+    echo "✅ 已清理所有孤儿进程"
+  else
+    echo "❌ 已取消清理"
+  fi
+fi

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -8,6 +8,14 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     setupFiles: ["./src/test/setup.ts"],
+    // 进程池配置 - 防止孤儿进程
+    pool: "forks",
+    poolOptions: {
+      forks: {
+        maxForks: 3, // 限制最多 3 个 worker 进程
+        minForks: 1, // 最少 1 个 worker 进程
+      },
+    },
     // 避免 Vitest 误执行 Playwright 的 e2e 用例
     exclude: [
       "node_modules/**",


### PR DESCRIPTION
## Summary
- Limit Vitest worker pool to max 3 forks to reduce resource usage
- Add automatic cleanup mechanisms for orphaned test processes
- Create monitoring utility for process inspection

## Changes
- **vitest.config.mjs**: Configure fork pool with max 3 workers (down from 7-9)
- **package.json**: Add `test:cleanup` script and `pretest` hook for auto-cleanup
- **scripts/check-orphans.sh**: New utility to detect and clean orphaned processes

## Problem
Vitest workers become orphaned when test runs are interrupted (Ctrl+C, terminal close), accumulating 20+ GB RAM usage over time.

## Solution
1. **Limit workers**: Reduce from 7-9 to max 3 processes
2. **Auto-cleanup**: Run cleanup before each test execution
3. **Manual tools**: Provide inspection/cleanup script for maintenance

## Test Plan
- [x] Verify vitest config syntax is valid
- [x] Test `npm run test:cleanup` command
- [x] Test `./scripts/check-orphans.sh` utility
- [x] Confirm no orphaned processes exist after implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)