### PR TITLE
Add preact dependency to unblock npm ci

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "node-geocoder": "^4.4.1",
         "nodemailer": "^6.10.1",
         "pinyin-pro": "^3.18.4",
+        "preact": "10.11.3",
         "prisma": "^6.16.2",
         "react": "19.1.0",
         "react-dom": "19.1.0",
@@ -290,6 +291,17 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@auth/prisma-adapter/node_modules/preact": {
+      "version": "10.24.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
+      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/@auth/prisma-adapter/node_modules/preact-render-to-string": {
@@ -12837,9 +12849,9 @@
       }
     },
     "node_modules/preact": {
-      "version": "10.24.3",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
-      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+      "version": "10.11.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.3.tgz",
+      "integrity": "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==",
       "license": "MIT",
       "peer": true,
       "funding": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "node-geocoder": "^4.4.1",
     "nodemailer": "^6.10.1",
     "pinyin-pro": "^3.18.4",
+    "preact": "10.11.3",
     "prisma": "^6.16.2",
     "react": "19.1.0",
     "react-dom": "19.1.0",


### PR DESCRIPTION
## Summary
- add `preact@10.11.3` to package.json so the lockfile matches npm ci expectations
- regenerate package-lock.json to include the root preact entry

## Testing
- npm ci --cache .npm-cache
- npm run lint
- npm run type-check
- npm run test:run