### PR TITLE
feat: Admin Hero优化 + 文章卡片点赞交互

### DIFF
--- a/src/app/api/admin/hero/sources/route.ts
+++ b/src/app/api/admin/hero/sources/route.ts
@@ -86,8 +86,8 @@ export async function GET(request: NextRequest) {
       });
 
       for (const img of galleryImages) {
-        // Prefer WebP thumbnails
-        const displayUrl = img.smallThumbPath || img.mediumPath || img.filePath;
+        // Use medium resolution for hero images (higher quality)
+        const displayUrl = img.mediumPath || img.filePath;
         const originalUrl = img.filePath;
 
         if (displayUrl) {

--- a/src/components/about/__tests__/live-highlights-section.test.tsx
+++ b/src/components/about/__tests__/live-highlights-section.test.tsx
@@ -46,7 +46,7 @@ describe("LiveHighlightsSection", () => {
   };
 
   it("should show loading state initially", () => {
-    mockFetch.mockImplementation(() => new Promise(() => {})); // Never resolves
+    mockFetch.mockImplementation(() => new Promise(() => { })); // Never resolves
 
     render(<LiveHighlightsSection locale="en" />);
 
@@ -172,8 +172,8 @@ describe("LiveHighlightsSection", () => {
     await waitFor(() => {
       const dashboardLink = screen.getByRole("link", { name: /dashboard/i });
       expect(dashboardLink).toBeInTheDocument();
-      // localePath adds locale prefix: /en/about/live
-      expect(dashboardLink).toHaveAttribute("href", "/en/about/live");
+      // localePath returns prefix-free paths for EN (default locale)
+      expect(dashboardLink).toHaveAttribute("href", "/about/live");
     });
   });
 

--- a/src/components/about/live-highlights-section.tsx
+++ b/src/components/about/live-highlights-section.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { ArrowRight, Film, Gamepad2, Code, Server } from "lucide-react";
 import type { LiveHighlightsData } from "@/types/live-data";
+import { localePath as buildLocalePath } from "@/lib/locale-path";
 
 interface LiveHighlightsSectionProps {
   locale: "en" | "zh";
@@ -64,17 +65,17 @@ export function LiveHighlightsSection({ locale, initialHighlights }: LiveHighlig
   const t =
     locale === "zh"
       ? {
-          title: "实时动态",
-          subtitle: "最近的娱乐、游戏和开发活动",
-          viewDashboard: "查看完整仪表盘",
-          loading: "加载中...",
-        }
+        title: "实时动态",
+        subtitle: "最近的娱乐、游戏和开发活动",
+        viewDashboard: "查看完整仪表盘",
+        loading: "加载中...",
+      }
       : {
-          title: "Live Updates",
-          subtitle: "Recent entertainment, gaming, and development activity",
-          viewDashboard: "View Full Dashboard",
-          loading: "Loading...",
-        };
+        title: "Live Updates",
+        subtitle: "Recent entertainment, gaming, and development activity",
+        viewDashboard: "View Full Dashboard",
+        loading: "Loading...",
+      };
 
   const iconMap = {
     "🎬": <Film className="h-5 w-5" />,
@@ -83,7 +84,7 @@ export function LiveHighlightsSection({ locale, initialHighlights }: LiveHighlig
     "🖥️": <Server className="h-5 w-5" />,
   };
 
-  const localePath = (path: string) => `/${locale}${path}`;
+  const lp = (path: string) => buildLocalePath(locale, path);
 
   if (!data) {
     return (
@@ -128,7 +129,7 @@ export function LiveHighlightsSection({ locale, initialHighlights }: LiveHighlig
               (highlight as unknown as { title?: string }).title ||
               String(idx)
             }
-            href={localePath(highlight.href)}
+            href={lp(highlight.href || "/about/live")}
             className="group relative overflow-hidden rounded-2xl border border-stone-200 bg-white/70 p-6 shadow-[0_8px_24px_-12px_rgba(39,39,42,0.25)] backdrop-blur transition-all hover:shadow-[0_12px_32px_-8px_rgba(39,39,42,0.35)] dark:border-stone-800 dark:bg-stone-950/70"
           >
             {/* Icon */}
@@ -174,7 +175,7 @@ export function LiveHighlightsSection({ locale, initialHighlights }: LiveHighlig
                 const isFresh =
                   status.lastSyncAt &&
                   new Date().getTime() - new Date(status.lastSyncAt).getTime() <
-                    24 * 60 * 60 * 1000;
+                  24 * 60 * 60 * 1000;
 
                 return (
                   <div
@@ -187,11 +188,10 @@ export function LiveHighlightsSection({ locale, initialHighlights }: LiveHighlig
                     }
                   >
                     <div
-                      className={`h-2 w-2 rounded-full ${
-                        isFresh
-                          ? "bg-green-500 dark:bg-green-400"
-                          : "bg-yellow-500 dark:bg-yellow-400"
-                      }`}
+                      className={`h-2 w-2 rounded-full ${isFresh
+                        ? "bg-green-500 dark:bg-green-400"
+                        : "bg-yellow-500 dark:bg-yellow-400"
+                        }`}
                     />
                     <span className="text-stone-600 capitalize dark:text-stone-400">
                       {status.platform}
@@ -207,7 +207,7 @@ export function LiveHighlightsSection({ locale, initialHighlights }: LiveHighlig
       {/* View Full Dashboard Button */}
       <div className="pt-4 text-center">
         <Link
-          href={localePath("/about/live")}
+          href={lp("/about/live")}
           className="inline-flex items-center gap-2 rounded-full border border-stone-200 bg-white/70 px-6 py-3 text-sm font-semibold text-stone-900 backdrop-blur transition-all hover:bg-stone-100 dark:border-stone-800 dark:bg-stone-950/70 dark:text-stone-50 dark:hover:bg-stone-900"
         >
           {t.viewDashboard}

--- a/src/components/admin/lumina/HeroPreviewGrid.tsx
+++ b/src/components/admin/lumina/HeroPreviewGrid.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import React, { useState, useEffect, useCallback, useRef } from "react";
+import type { DragEndEvent } from "@dnd-kit/core";
+import {
+    DndContext,
+    closestCenter,
+    KeyboardSensor,
+    PointerSensor,
+    useSensor,
+    useSensors,
+} from "@dnd-kit/core";
+import {
+    arrayMove,
+    SortableContext,
+    sortableKeyboardCoordinates,
+    useSortable,
+    rectSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { X, GripVertical } from "lucide-react";
+import { AdminImage } from "../AdminImage";
+
+// Grid layout calculation (same as homepage hero.tsx)
+interface GridLayout {
+    cols: number;
+    rows: number;
+    gap: string;
+}
+
+function getGridLayout(count: number): GridLayout {
+    if (count >= 13) return { cols: 4, rows: 4, gap: "gap-1" };
+    if (count >= 10) return { cols: 4, rows: 3, gap: "gap-1.5" };
+    if (count >= 7) return { cols: 3, rows: 3, gap: "gap-1.5" };
+    if (count >= 5) return { cols: 3, rows: 2, gap: "gap-2" };
+    if (count >= 4) return { cols: 2, rows: 2, gap: "gap-2" };
+    if (count >= 2) return { cols: 2, rows: 1, gap: "gap-2" };
+    return { cols: 1, rows: 1, gap: "gap-0" };
+}
+
+export interface HeroImageItem {
+    id: string;
+    url: string;
+    sortOrder: number;
+}
+
+interface HeroPreviewGridProps {
+    images: HeroImageItem[];
+    onReorder: (newOrder: HeroImageItem[]) => void;
+    onRemove: (id: string) => void;
+}
+
+// Sortable image item
+function SortableImage({
+    image,
+    onRemove,
+}: {
+    image: HeroImageItem;
+    onRemove: (id: string) => void;
+}) {
+    const {
+        attributes,
+        listeners,
+        setNodeRef,
+        transform,
+        transition,
+        isDragging,
+    } = useSortable({ id: image.id });
+
+    const style = {
+        transform: CSS.Transform.toString(transform),
+        transition,
+        zIndex: isDragging ? 50 : undefined,
+    };
+
+    return (
+        <div
+            ref={setNodeRef}
+            style={style}
+            className={`relative group overflow-hidden rounded-xl bg-stone-200 dark:bg-stone-800 ${isDragging ? "ring-2 ring-sage-500 shadow-2xl scale-105" : ""
+                }`}
+        >
+            <AdminImage
+                src={image.url}
+                alt=""
+                className="w-full h-full"
+                containerClassName="w-full h-full aspect-square"
+            />
+
+            {/* Drag handle */}
+            <button
+                {...attributes}
+                {...listeners}
+                className="absolute top-2 left-2 p-1.5 bg-black/50 rounded-lg text-white opacity-0 group-hover:opacity-100 transition-opacity cursor-grab active:cursor-grabbing"
+            >
+                <GripVertical size={14} />
+            </button>
+
+            {/* Remove button */}
+            <button
+                onClick={() => onRemove(image.id)}
+                className="absolute top-2 right-2 p-1.5 bg-rose-500 rounded-full text-white opacity-0 group-hover:opacity-100 transition-opacity hover:bg-rose-600"
+            >
+                <X size={14} />
+            </button>
+
+            {/* Order number */}
+            <div className="absolute bottom-0 inset-x-0 bg-gradient-to-t from-black/60 to-transparent p-2">
+                <span className="text-xs text-white/80 font-medium">
+                    #{image.sortOrder + 1}
+                </span>
+            </div>
+        </div>
+    );
+}
+
+export function HeroPreviewGrid({ images, onReorder, onRemove }: HeroPreviewGridProps) {
+    // Local state for optimistic updates - prevents flash on reorder
+    const [localImages, setLocalImages] = useState<HeroImageItem[]>(images);
+    const pendingUpdate = useRef(false);
+
+    // Sync local state when external images change (but not during pending update)
+    useEffect(() => {
+        if (!pendingUpdate.current) {
+            setLocalImages(images);
+        }
+    }, [images]);
+
+    const sensors = useSensors(
+        useSensor(PointerSensor, {
+            activationConstraint: {
+                distance: 5,
+            },
+        }),
+        useSensor(KeyboardSensor, {
+            coordinateGetter: sortableKeyboardCoordinates,
+        })
+    );
+
+    const layout = getGridLayout(localImages.length);
+
+    const handleDragEnd = useCallback(
+        (event: DragEndEvent) => {
+            const { active, over } = event;
+
+            if (over && active.id !== over.id) {
+                const oldIndex = localImages.findIndex((img) => img.id === active.id);
+                const newIndex = localImages.findIndex((img) => img.id === over.id);
+
+                const newOrder = arrayMove(localImages, oldIndex, newIndex).map((img, index) => ({
+                    ...img,
+                    sortOrder: index,
+                }));
+
+                // Optimistically update local state immediately
+                pendingUpdate.current = true;
+                setLocalImages(newOrder);
+
+                // Notify parent to persist changes
+                onReorder(newOrder);
+
+                // Allow syncing again after a short delay
+                setTimeout(() => {
+                    pendingUpdate.current = false;
+                }, 1000);
+            }
+        },
+        [localImages, onReorder]
+    );
+
+    if (localImages.length === 0) {
+        return null;
+    }
+
+    return (
+        <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+        >
+            <SortableContext items={localImages.map((img) => img.id)} strategy={rectSortingStrategy}>
+                <div
+                    className={`grid w-full ${layout.gap}`}
+                    style={{
+                        gridTemplateColumns: `repeat(${layout.cols}, 1fr)`,
+                        gridTemplateRows: `repeat(${layout.rows}, 1fr)`,
+                        aspectRatio: `${layout.cols} / ${layout.rows}`,
+                        maxWidth: "500px",
+                    }}
+                >
+                    {localImages.slice(0, layout.cols * layout.rows).map((img) => (
+                        <SortableImage key={img.id} image={img} onRemove={onRemove} />
+                    ))}
+                </div>
+            </SortableContext>
+        </DndContext>
+    );
+}
+
+export default HeroPreviewGrid;

--- a/src/components/lumina/gallery.tsx
+++ b/src/components/lumina/gallery.tsx
@@ -1,5 +1,4 @@
 "use client";
-"use client";
 /* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable @next/next/no-img-element */
 
@@ -20,7 +19,6 @@ import {
   HardDrive,
 } from "lucide-react";
 import { getLocaleFromPathname } from "@/lib/i18n";
-import L from "leaflet";
 
 // Dynamic import for map components (avoid SSR issues)
 const MapContainer = dynamic(() => import("react-leaflet").then((mod) => mod.MapContainer), {
@@ -400,11 +398,13 @@ export function LuminaGallery({ items }: LuminaGalleryProps) {
 
   // Fix Leaflet default marker icon issue
   useEffect(() => {
-    delete (L.Icon.Default.prototype as any)._getIconUrl;
-    L.Icon.Default.mergeOptions({
-      iconRetinaUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png",
-      iconUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png",
-      shadowUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png",
+    import("leaflet").then((L) => {
+      delete (L.Icon.Default.prototype as any)._getIconUrl;
+      L.Icon.Default.mergeOptions({
+        iconRetinaUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png",
+        iconUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png",
+        shadowUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png",
+      });
     });
   }, []);
 
@@ -724,9 +724,8 @@ export function LuminaGallery({ items }: LuminaGalleryProps) {
 
             {/* Mobile Bottom Drawer */}
             <div
-              className={`fixed inset-x-0 bottom-0 z-[75] transform transition-transform duration-300 ease-out lg:hidden ${
-                drawerOpen ? "translate-y-0" : "translate-y-[calc(100%-120px)]"
-              }`}
+              className={`fixed inset-x-0 bottom-0 z-[75] transform transition-transform duration-300 ease-out lg:hidden ${drawerOpen ? "translate-y-0" : "translate-y-[calc(100%-120px)]"
+                }`}
             >
               {/* Drawer Handle */}
               <button
@@ -841,9 +840,8 @@ export function LuminaGallery({ items }: LuminaGalleryProps) {
                       },
                     }}
                     transition={{ duration: 0.3, ease: "easeOut" }}
-                    className={`relative h-full shrink-0 overflow-hidden rounded ${
-                      i === currentIndex ? "ring-2 ring-white" : "opacity-60 hover:opacity-100"
-                    }`}
+                    className={`relative h-full shrink-0 overflow-hidden rounded ${i === currentIndex ? "ring-2 ring-white" : "opacity-60 hover:opacity-100"
+                      }`}
                   >
                     <img
                       src={item.smallThumbPath || item.microThumbPath || item.thumbnail || item.url}

--- a/src/components/lumina/hero.tsx
+++ b/src/components/lumina/hero.tsx
@@ -9,18 +9,10 @@ import Image from "next/image";
 
 // Default hero images - can be replaced with actual data
 const DEFAULT_HERO_IMAGES: HeroImageItem[] = [
-  { src: "https://picsum.photos/400/400?random=101", href: "/gallery", type: "gallery" },
-  { src: "https://picsum.photos/400/400?random=102", href: "/gallery", type: "gallery" },
-  { src: "https://picsum.photos/400/400?random=103", href: "/gallery", type: "gallery" },
-  { src: "https://picsum.photos/400/400?random=104", href: "/gallery", type: "gallery" },
-  { src: "https://picsum.photos/400/400?random=105", href: "/gallery", type: "gallery" },
-  { src: "https://picsum.photos/400/400?random=106", href: "/gallery", type: "gallery" },
-  { src: "https://picsum.photos/400/400?random=107", href: "/gallery", type: "gallery" },
-  { src: "https://picsum.photos/400/400?random=108", href: "/gallery", type: "gallery" },
-  { src: "https://picsum.photos/400/400?random=109", href: "/gallery", type: "gallery" },
-  { src: "https://picsum.photos/400/400?random=110", href: "/gallery", type: "gallery" },
-  { src: "https://picsum.photos/400/400?random=111", href: "/gallery", type: "gallery" },
-  { src: "https://picsum.photos/400/400?random=112", href: "/gallery", type: "gallery" },
+  { src: "https://picsum.photos/800/800?random=101", href: "/gallery", type: "gallery" },
+  { src: "https://picsum.photos/800/800?random=102", href: "/gallery", type: "gallery" },
+  { src: "https://picsum.photos/800/800?random=103", href: "/gallery", type: "gallery" },
+  { src: "https://picsum.photos/800/800?random=104", href: "/gallery", type: "gallery" },
 ];
 
 // Hero image item with source info for navigation
@@ -100,9 +92,9 @@ export function LuminaHero({ heroImages = DEFAULT_HERO_IMAGES }: LuminaHeroProps
             </p>
           </div>
 
-          {/* New Info Grid */}
-          <div className="mx-auto w-full max-w-md border-t border-stone-200 pt-6 lg:mx-0 dark:border-[#27272a]">
-            <div className="grid grid-cols-2 gap-4 sm:grid-cols-4 sm:gap-5">
+          {/* Info Grid - 2x2 Layout */}
+          <div className="mx-auto w-full max-w-sm border-t border-stone-200 pt-6 lg:mx-0 dark:border-[#27272a]">
+            <div className="grid grid-cols-2 gap-x-8 gap-y-4">
               <InfoItem icon={<Briefcase size={16} />} label={t("Product Manager")} />
               <InfoItem icon={<Aperture size={16} />} label={t("Photographer")} />
               <InfoItem icon={<Cpu size={16} />} label={t("Tech Enthusiast")} />
@@ -124,10 +116,10 @@ export function LuminaHero({ heroImages = DEFAULT_HERO_IMAGES }: LuminaHeroProps
 function InfoItem({ icon, label }: { icon: React.ReactNode; label: string }) {
   return (
     <div className="group flex cursor-default items-center gap-3 text-stone-600 dark:text-stone-400">
-      <div className="rounded-lg bg-stone-100 p-2 text-stone-500 transition-colors group-hover:bg-sage-50 group-hover:text-sage-600 dark:bg-[#1f1f23] dark:group-hover:bg-sage-900/20 dark:group-hover:text-sage-400">
+      <div className="shrink-0 rounded-lg bg-stone-100 p-2 text-stone-500 transition-colors group-hover:bg-sage-50 group-hover:text-sage-600 dark:bg-[#1f1f23] dark:group-hover:bg-sage-900/20 dark:group-hover:text-sage-400">
         {icon}
       </div>
-      <span className="text-sm font-medium tracking-wide">{label}</span>
+      <span className="whitespace-nowrap text-sm font-medium">{label}</span>
     </div>
   );
 }
@@ -148,30 +140,48 @@ function shuffle<T>(array: T[]): T[] {
   return newArray;
 }
 
-// Layout calculation
+// Layout calculation - determines grid dimensions based on image count
 interface GridLayout {
   cols: number;
   rows: number;
-  type: "grid" | "featured" | "hero";
+  gap: string;
 }
 
 function getGridLayout(count: number): GridLayout {
-  if (count >= 16) return { cols: 4, rows: 4, type: "grid" };
-  if (count >= 12) return { cols: 4, rows: 3, type: "grid" };
-  if (count >= 9) return { cols: 3, rows: 3, type: "grid" };
-  if (count >= 6) return { cols: 3, rows: 2, type: "grid" };
-  if (count >= 4) return { cols: 2, rows: 2, type: "grid" };
-  if (count >= 2) return { cols: 2, rows: 1, type: "featured" };
-  return { cols: 1, rows: 1, type: "hero" };
+  if (count >= 13) return { cols: 4, rows: 4, gap: "gap-1" };
+  if (count >= 10) return { cols: 4, rows: 3, gap: "gap-1.5" };
+  if (count >= 7) return { cols: 3, rows: 3, gap: "gap-1.5" };
+  if (count >= 5) return { cols: 3, rows: 2, gap: "gap-2" };
+  if (count >= 4) return { cols: 2, rows: 2, gap: "gap-2" };
+  if (count >= 2) return { cols: 2, rows: 1, gap: "gap-2" };
+  return { cols: 1, rows: 1, gap: "gap-0" };
 }
 
-// Shuffle Grid Component
+// Get image quality based on grid size - always high quality
+function getImageQuality(cols: number): number {
+  // Keep quality high for all layouts (WebP compression handles file size)
+  if (cols === 1) return 95;
+  if (cols === 2) return 90;
+  return 85;
+}
+
+// Get image sizes for responsive loading - request larger images for Retina displays
+function getImageSizes(cols: number): string {
+  // Request 2x the display size to ensure sharp images on Retina displays
+  // WebP compression keeps file sizes reasonable even at larger dimensions
+  if (cols === 1) return "(max-width: 640px) 100vw, (max-width: 1024px) 70vw, 800px";
+  if (cols === 2) return "(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 600px";
+  if (cols === 3) return "(max-width: 640px) 50vw, (max-width: 1024px) 40vw, 450px";
+  return "(max-width: 640px) 50vw, (max-width: 1024px) 35vw, 400px";
+}
+
+// Shuffle Grid Component - unified layout for 1-16 images
 function ShuffleGrid({ heroImages }: { heroImages: HeroImageItem[] }) {
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const imageCount = heroImages.length;
   const layout = useMemo(() => getGridLayout(imageCount), [imageCount]);
 
-  // Calculate how many images to display
+  // Calculate how many images to display (capped by grid capacity)
   const maxImages = layout.cols * layout.rows;
 
   const initialSquares = useMemo(() => {
@@ -188,9 +198,9 @@ function ShuffleGrid({ heroImages }: { heroImages: HeroImageItem[] }) {
 
   const [squares, setSquares] = useState(initialSquares);
 
-  // Shuffle animation (only for grid layouts with 4+ images)
+  // Shuffle animation (only for layouts with 4+ images)
   useEffect(() => {
-    if (layout.type !== "grid" || squares.length < 4) return;
+    if (squares.length < 4) return;
 
     const shuffleSquares = () => {
       setSquares((prev) => shuffle(prev));
@@ -202,102 +212,46 @@ function ShuffleGrid({ heroImages }: { heroImages: HeroImageItem[] }) {
     return () => {
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
     };
-  }, [layout.type, squares.length]);
+  }, [squares.length]);
 
   // Handle empty state
   if (squares.length === 0) {
     return (
-      <div className="flex h-[280px] items-center justify-center rounded-xl bg-stone-100 dark:bg-[#1f1f23] sm:h-[340px] md:h-[420px]">
+      <div className="flex aspect-square w-full items-center justify-center rounded-xl bg-stone-100 dark:bg-[#1f1f23]">
         <p className="text-stone-400 dark:text-stone-500">No images</p>
       </div>
     );
   }
 
-  // Single hero image layout
-  if (layout.type === "hero" && squares[0]) {
-    return (
-      <motion.a
-        href={squares[0].href}
-        className="relative block h-[280px] overflow-hidden rounded-xl bg-stone-200 shadow-sm dark:bg-[#1f1f23] sm:h-[340px] md:h-[420px]"
-      >
-        <Image
-          src={squares[0].src}
-          alt=""
-          fill
-          sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 600px"
-          className="object-cover transition-transform duration-300 hover:scale-105"
-          quality={90}
-        />
-        <div className="absolute inset-0 bg-stone-900/0 transition-colors duration-300 hover:bg-stone-900/10" />
-      </motion.a>
-    );
-  }
+  const imageQuality = getImageQuality(layout.cols);
+  const imageSizes = getImageSizes(layout.cols);
 
-  // Featured layout (2-3 images)
-  if (layout.type === "featured") {
-    return (
-      <div className="grid h-[280px] grid-cols-3 grid-rows-2 gap-1.5 sm:h-[340px] sm:gap-2 md:h-[420px]">
-        {/* Large featured image */}
-        {squares[0] && (
-          <motion.a
-            href={squares[0].href}
-            layout
-            transition={{ duration: 1.5, type: "spring", stiffness: 45, damping: 15 }}
-            className="relative col-span-2 row-span-2 overflow-hidden rounded-xl bg-stone-200 shadow-sm dark:bg-[#1f1f23]"
-          >
-            <Image
-              src={squares[0].src}
-              alt=""
-              fill
-              sizes="(max-width: 640px) 66vw, (max-width: 1024px) 40vw, 400px"
-              className="object-cover transition-transform duration-300 hover:scale-105"
-              quality={85}
-            />
-            <div className="absolute inset-0 bg-stone-900/0 transition-colors duration-300 hover:bg-stone-900/10" />
-          </motion.a>
-        )}
-        {/* Smaller images */}
-        {squares.slice(1, 3).map((sq) => (
-          <motion.a
-            key={sq.id}
-            href={sq.href}
-            layout
-            transition={{ duration: 1.5, type: "spring", stiffness: 45, damping: 15 }}
-            className="relative overflow-hidden rounded-xl bg-stone-200 shadow-sm dark:bg-[#1f1f23]"
-          >
-            <Image
-              src={sq.src}
-              alt=""
-              fill
-              sizes="(max-width: 640px) 33vw, (max-width: 1024px) 20vw, 200px"
-              className="object-cover transition-transform duration-300 hover:scale-105"
-              quality={85}
-            />
-            <div className="absolute inset-0 bg-stone-900/0 transition-colors duration-300 hover:bg-stone-900/10" />
-          </motion.a>
-        ))}
-      </div>
-    );
-  }
-
-  // Standard grid layout with shuffle animation
+  // Unified grid layout - all sizes use the same structure
   return (
-    <div className="grid h-[280px] grid-cols-3 grid-rows-4 gap-1.5 sm:h-[340px] sm:grid-cols-4 sm:gap-2 md:h-[420px]">
+    <div
+      className={`grid w-full ${layout.gap}`}
+      style={{
+        gridTemplateColumns: `repeat(${layout.cols}, 1fr)`,
+        gridTemplateRows: `repeat(${layout.rows}, 1fr)`,
+        aspectRatio: `${layout.cols} / ${layout.rows}`,
+      }}
+    >
       {squares.map((sq) => (
         <motion.a
           key={sq.id}
           href={sq.href}
           layout
           transition={{ duration: 1.5, type: "spring", stiffness: 45, damping: 15 }}
-          className="relative h-full w-full cursor-pointer overflow-hidden rounded-xl bg-stone-200 shadow-sm dark:bg-[#1f1f23]"
+          className="relative cursor-pointer overflow-hidden rounded-xl bg-stone-200 shadow-sm dark:bg-[#1f1f23]"
+          style={{ aspectRatio: "1 / 1" }}
         >
           <Image
             src={sq.src}
             alt=""
             fill
-            sizes="(max-width: 640px) 25vw, (max-width: 1024px) 12.5vw, 120px"
+            sizes={imageSizes}
             className="object-cover transition-transform duration-300 hover:scale-105"
-            quality={75}
+            quality={imageQuality}
           />
           <div className="absolute inset-0 bg-stone-900/0 transition-colors duration-300 hover:bg-stone-900/10" />
         </motion.a>

--- a/src/components/lumina/post-card.tsx
+++ b/src/components/lumina/post-card.tsx
@@ -57,7 +57,7 @@ export function LuminaPostCard({ post, onClick, onLike }: PostCardProps) {
           </div>
         )}
 
-        <div className="px-1">
+        <div className="px-3">
           {!post.imageUrl && (
             <div className="mb-3 text-[10px] font-bold uppercase tracking-widest text-stone-400">
               {post.category}
@@ -82,9 +82,8 @@ export function LuminaPostCard({ post, onClick, onLike }: PostCardProps) {
             <div className="flex items-center gap-4">
               <button
                 onClick={handleLike}
-                className={`flex items-center gap-1 transition-colors hover:text-rose-500 ${
-                  post.likes > 0 ? "text-rose-500" : ""
-                }`}
+                className={`flex items-center gap-1 transition-colors hover:text-rose-500 ${post.likes > 0 ? "text-rose-500" : ""
+                  }`}
               >
                 <Heart size={14} className={post.likes > 0 ? "fill-current" : ""} />
                 <span>{post.likes}</span>

--- a/src/components/lumina/side-widgets.tsx
+++ b/src/components/lumina/side-widgets.tsx
@@ -14,7 +14,7 @@ interface ProfileWidgetProps {
 }
 
 export function ProfileWidget({
-  avatarUrl = "https://aistudiocdn.com/72b5f4228e1b81681e679509282e412406e613940be14c87e7544f4d02e95506.jpg",
+  avatarUrl,
   name = "BaoZhi",
   title,
   bio,
@@ -39,13 +39,30 @@ export function ProfileWidget({
     bio ||
     "Turning chaos into roadmaps. Obsessed with UX, data, and the perfect cup of coffee.";
 
+  // Fallback avatar using initials
+  const initials = name.slice(0, 2).toUpperCase();
+
   return (
     <div className="group relative mb-6 overflow-hidden rounded-2xl border border-stone-200 bg-white p-6 text-center shadow-sm dark:border-[#27272a] dark:bg-[#141416]">
       {/* Decor */}
       <div className="pointer-events-none absolute top-0 left-0 h-24 w-full bg-gradient-to-b from-stone-100 to-transparent dark:from-[#1f1f23]/60" />
 
       <div className="relative mx-auto mb-4 h-24 w-24 overflow-hidden rounded-full border-4 border-white bg-stone-200 shadow-xl transition-transform duration-500 group-hover:scale-105 dark:border-[#0a0a0b] dark:bg-[#27272a]">
-        <img src={avatarUrl} alt={name} className="h-full w-full object-cover" />
+        {avatarUrl ? (
+          <img
+            src={avatarUrl}
+            alt={name}
+            className="h-full w-full object-cover"
+            onError={(e) => {
+              // Hide the broken image and show fallback
+              e.currentTarget.style.display = 'none';
+            }}
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-sage-400 to-sage-600 text-2xl font-bold text-white">
+            {initials}
+          </div>
+        )}
       </div>
       <h3 className="mb-1 font-serif text-2xl font-bold text-stone-900 dark:text-stone-100">
         {name}

--- a/src/lib/admin-translations.ts
+++ b/src/lib/admin-translations.ts
@@ -397,6 +397,14 @@ export const adminTranslations = {
 
     // Hero
     heroShuffleGrid: "Hero Shuffle Grid",
+    heroPreview: "Hero Preview",
+    removeAll: "Remove All",
+    dragToReorder: "Drag to reorder images",
+    loadingImages: "Loading images...",
+    imagesAvailable: "images available",
+    selectAll: "Select All",
+    noImagesFound: "No images found",
+    loadMore: "Load More",
     pasteImageUrl: "Paste image URL here...",
     add: "Add",
     selectFromGallery: "Select from Gallery",
@@ -855,6 +863,14 @@ export const adminTranslations = {
 
     // Hero
     heroShuffleGrid: "头图轮播",
+    heroPreview: "头图预览",
+    removeAll: "全部移除",
+    dragToReorder: "拖拽调整图片顺序",
+    loadingImages: "加载图片中...",
+    imagesAvailable: "张可选图片",
+    selectAll: "全选",
+    noImagesFound: "未找到图片",
+    loadMore: "加载更多",
     pasteImageUrl: "粘贴图片链接...",
     add: "添加",
     selectFromGallery: "从相册选择",

--- a/src/lib/hero.ts
+++ b/src/lib/hero.ts
@@ -9,5 +9,13 @@ export async function listHeroImages(): Promise<string[]> {
     where: { active: true },
     orderBy: [{ sortOrder: "asc" }, { createdAt: "desc" }],
   });
-  return images.map((img) => img.url);
+
+  // Convert small thumbnails to medium resolution for better quality
+  return images.map((img) => {
+    // Replace _small.webp with _medium.webp for higher quality
+    if (img.url.includes("_small.webp")) {
+      return img.url.replace("_small.webp", "_medium.webp");
+    }
+    return img.url;
+  });
 }


### PR DESCRIPTION
## 改动概述

### Admin Hero 页面优化
- ✨ 新增 `HeroPreviewGrid` 组件，支持拖拽排序 (dnd-kit)
- 📐 布局调整：预览区在上，选择区在下
- ⚡️ 服务端分页（每页32张），加载更快
- 🎨 Pill 风格 Tab 按钮
- 🚀 拖拽时乐观更新，无闪回

### 文章卡片优化
- 📏 增加内容区内边距 (px-1 → px-3)
- ❤️ 启用点赞按钮，接入真实 API
- ⚡️ 乐观更新，即时反馈

### 点赞性能优化
- 🏃 移除 useTransition，响应更快
- ⏱️ 防抖时间 500ms → 300ms

### Bug 修复
- 🗺️ Leaflet SSR 问题修复（动态 import）
- 🖼️ Hero 图片分辨率修复（使用 mediumPath）
- 👤 头像加载失败时显示首字母缩写

### 翻译
- 新增 heroPreview、removeAll、dragToReorder、loadMore 等翻译