### PR TITLE
fix(security): upgrade jsonwebtoken to fix jws CVE-2025-65945

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "date-fns": "^4.1.0",
         "exifr": "^7.1.3",
         "framer-motion": "^12.23.24",
-        "jsonwebtoken": "^9.0.2",
+        "jsonwebtoken": "9.0.3",
         "jszip": "^3.10.1",
         "leaflet": "^1.9.4",
         "lru-cache": "^11.0.2",
@@ -6696,6 +6696,8 @@
     },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
     "node_modules/c12": {
@@ -7564,6 +7566,8 @@
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
+      "resolved": "https://registry.npmmirror.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -9975,10 +9979,12 @@
       }
     },
     "node_modules/jsonwebtoken": {
-      "version": "9.0.2",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmmirror.com/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
       "license": "MIT",
       "dependencies": {
-        "jws": "^3.2.2",
+        "jws": "^4.0.1",
         "lodash.includes": "^4.3.0",
         "lodash.isboolean": "^3.0.3",
         "lodash.isinteger": "^4.0.4",
@@ -10019,7 +10025,9 @@
       }
     },
     "node_modules/jwa": {
-      "version": "1.4.2",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "license": "MIT",
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
@@ -10028,10 +10036,12 @@
       }
     },
     "node_modules/jws": {
-      "version": "3.2.2",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmmirror.com/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
       "license": "MIT",
       "dependencies": {
-        "jwa": "^1.4.1",
+        "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -12966,6 +12976,8 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmmirror.com/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "date-fns": "^4.1.0",
     "exifr": "^7.1.3",
     "framer-motion": "^12.23.24",
-    "jsonwebtoken": "^9.0.2",
+    "jsonwebtoken": "9.0.3",
     "jszip": "^3.10.1",
     "leaflet": "^1.9.4",
     "lru-cache": "^11.0.2",


### PR DESCRIPTION
## Security Fix

Fixes CVE-2025-65945: auth0/node-jws Improperly Verifies HMAC Signature

## Changes
- Upgrade jsonwebtoken 9.0.2 → 9.0.3
- This updates jws 3.2.2 → 4.0.1