### PR TITLE
fix: use small thumbs for hero grid

### DIFF
--- a/src/lib/hero.ts
+++ b/src/lib/hero.ts
@@ -4,6 +4,37 @@ import { unstable_cache } from "next/cache";
 // Cache tag for hero images invalidation
 export const HERO_IMAGES_TAG = "hero-images";
 
+const INTERNAL_HOST_HINTS = ["r2.dev", "r2.cloudflarestorage.com", "dybzy.com"];
+
+function isLikelyInternalUrl(url: string): boolean {
+  if (url.startsWith("/")) return true;
+  try {
+    const host = new URL(url).hostname;
+    return INTERNAL_HOST_HINTS.some((hint) => host.includes(hint));
+  } catch {
+    return false;
+  }
+}
+
+function toHeroThumbUrl(url: string): string {
+  const [path, query] = url.split("?");
+  const isInternal = isLikelyInternalUrl(url);
+  const isCover = path.includes("/covers/") || path.includes("covers/");
+
+  if (path.includes("_small.webp")) return url;
+  if (path.includes("_medium.webp") && isInternal && !isCover) {
+    const replaced = path.replace("_medium.webp", "_small.webp");
+    return query ? `${replaced}?${query}` : replaced;
+  }
+
+  if (isInternal && !isCover && /\.(jpe?g|png|webp|heic|heif)$/i.test(path)) {
+    const replaced = `${path.replace(/\.[^.]+$/, "")}_small.webp`;
+    return query ? `${replaced}?${query}` : replaced;
+  }
+
+  return url;
+}
+
 /**
  * 获取激活的 Hero 图片 URL 列表（内部实现）
  */
@@ -13,14 +44,8 @@ async function _listHeroImages(): Promise<string[]> {
     orderBy: [{ sortOrder: "asc" }, { createdAt: "desc" }],
   });
 
-  // Convert small thumbnails to medium resolution for better quality
-  return images.map((img) => {
-    // Replace _small.webp with _medium.webp for higher quality
-    if (img.url.includes("_small.webp")) {
-      return img.url.replace("_small.webp", "_medium.webp");
-    }
-    return img.url;
-  });
+  // Prefer small thumbnails to keep hero grid lightweight
+  return images.map((img) => toHeroThumbUrl(img.url));
 }
 
 /**
@@ -33,4 +58,3 @@ export const listHeroImages = unstable_cache(
   ["hero-images-list"],
   { revalidate: 60, tags: [HERO_IMAGES_TAG] }
 );
-


### PR DESCRIPTION
- serve small hero thumbnails at runtime to reduce payload\n- pick smallThumbPath when selecting hero images from gallery\n- keep selection state compatible with existing medium URLs